### PR TITLE
Remove follower loop and add a manual execution approach

### DIFF
--- a/pkg/chainfollower/chainfollower.go
+++ b/pkg/chainfollower/chainfollower.go
@@ -35,10 +35,6 @@ func NewChainFollower(rpc rpc.RpcTransportInterface) *ChainFollower {
 	return &ChainFollower{rpc: rpc, MessageChannelSize: 0}
 }
 
-func (c *ChainFollower) FetchStartingPos(initialChainPos *state.ChainPos) (*state.ChainPos, error) {
-	return c.fetchStartingPos(initialChainPos)
-}
-
 func (c *ChainFollower) GetNextMessage(chainPos *state.ChainPos) (messages.Message, error) {
 	blockHeader, err := c.rpc.GetBlockHeader(chainPos.BlockHash)
 	if err != nil {
@@ -116,7 +112,7 @@ func (c *ChainFollower) rollbackToOnChainBlock(fromHash string) (*state.ChainPos
 	}
 }
 
-func (c *ChainFollower) fetchStartingPos(initialChainPos *state.ChainPos) (*state.ChainPos, error) {
+func (c *ChainFollower) FetchStartingPos(initialChainPos *state.ChainPos) (*state.ChainPos, error) {
 	// Retry loop for transaction error or wrong-chain error.
 	for {
 		genesisHash, err := c.rpc.GetBlockHash(0)

--- a/pkg/chainfollower/chainfollower_test.go
+++ b/pkg/chainfollower/chainfollower_test.go
@@ -16,7 +16,7 @@ func TestBlockMessageReceived(t *testing.T) {
 
 	follower := NewChainFollower(testTransport)
 
-	chainPos := &state.ChainPos{
+	initialChainPos := &state.ChainPos{
 		BlockHash:   "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691",
 		BlockHeight: 0,
 	}
@@ -36,9 +36,16 @@ func TestBlockMessageReceived(t *testing.T) {
 		Hash: "0000000000000000000000000000000000000000000000000000000000000000",
 	})
 
-	messageChan := follower.Start(chainPos)
+	chainPos, err := follower.FetchStartingPos(initialChainPos)
+	if err != nil {
+		t.Errorf("Error fetching starting pos: %v", err)
+	}
 
-	rawMessage := <-messageChan
+	rawMessage, err := follower.GetNextMessage(chainPos)
+	if err != nil {
+		t.Errorf("Error fetching next message: %v", err)
+	}
+
 	if rawMessage == nil {
 		t.Errorf("Block message received is nil")
 	}
@@ -48,7 +55,10 @@ func TestBlockMessageReceived(t *testing.T) {
 		t.Errorf("Block message received is not correct")
 	}
 
-	rawMessage = <-messageChan
+	rawMessage, err = follower.GetNextMessage(rawMessage.(messages.BlockMessage).ChainPos)
+	if err != nil {
+		t.Errorf("Error fetching next message: %v", err)
+	}
 	if rawMessage == nil {
 		t.Errorf("Block message received is nil")
 	}
@@ -56,10 +66,6 @@ func TestBlockMessageReceived(t *testing.T) {
 	blockMessage = rawMessage.(messages.BlockMessage)
 	if blockMessage.Block.Hash != "0000000000000000000000000000000000000000000000000000000000000000" {
 		t.Errorf("Block message received is not correct")
-	}
-
-	if len(messageChan) != 0 {
-		t.Errorf("Shouldn't be messages if we are waiting on Next Hash")
 	}
 }
 
@@ -70,7 +76,7 @@ func TestRollbackMessage(t *testing.T) {
 
 	follower := NewChainFollower(testTransport)
 
-	chainPos := &state.ChainPos{
+	initialChainPos := &state.ChainPos{
 		BlockHash:   "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691",
 		BlockHeight: 0,
 	}
@@ -99,30 +105,48 @@ func TestRollbackMessage(t *testing.T) {
 		Confirmations:     -1,
 	})
 
-	messageChan := follower.Start(chainPos)
+	chainPos, err := follower.fetchStartingPos(initialChainPos)
+	if err != nil {
+		t.Errorf("Error fetching starting pos: %v", err)
+	}
 
-	first := (<-messageChan).(messages.BlockMessage)
-	second := (<-messageChan).(messages.BlockMessage)
-	rollback := (<-messageChan).(messages.RollbackMessage)
-	secondAgain := (<-messageChan).(messages.BlockMessage)
+	first, err := follower.GetNextMessage(chainPos)
+	if err != nil {
+		t.Errorf("Error fetching next message: %v", err)
+	}
 
-	if first.Block.Hash != "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691" {
+	second, err := follower.GetNextMessage(first.(messages.BlockMessage).ChainPos)
+	if err != nil {
+		t.Errorf("Error fetching next message: %v", err)
+	}
+
+	rollback, err := follower.GetNextMessage(second.(messages.BlockMessage).ChainPos)
+	if err != nil {
+		t.Errorf("Error fetching next message: %v", err)
+	}
+
+	secondAgain, err := follower.GetNextMessage(rollback.(messages.RollbackMessage).NewChainPos)
+	if err != nil {
+		t.Errorf("Error fetching next message: %v", err)
+	}
+
+	if first.(messages.BlockMessage).Block.Hash != "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691" {
 		t.Errorf("Block message received is not correct")
 	}
 
-	if second.Block.Hash != "0000000000000000000000000000000000000000000000000000000000000000" {
+	if second.(messages.BlockMessage).Block.Hash != "0000000000000000000000000000000000000000000000000000000000000000" {
 		t.Errorf("Block message received is not correct")
 	}
 
-	if rollback.NewChainPos.BlockHash != "0000000000000000000000000000000000000000000000000000000000000000" {
+	if rollback.(messages.RollbackMessage).NewChainPos.BlockHash != "0000000000000000000000000000000000000000000000000000000000000000" {
 		t.Errorf("Rollback message received is not correct")
 	}
 
-	if rollback.OldChainPos.BlockHash != "1111111111111111111111111111111111111111111111111111111111111111" {
+	if rollback.(messages.RollbackMessage).OldChainPos.BlockHash != "1111111111111111111111111111111111111111111111111111111111111111" {
 		t.Errorf("Rollback message received is not correct")
 	}
 
-	if secondAgain.Block.Hash != "0000000000000000000000000000000000000000000000000000000000000000" {
+	if secondAgain.(messages.BlockMessage).Block.Hash != "0000000000000000000000000000000000000000000000000000000000000000" {
 		t.Errorf("Block message received is not correct")
 	}
 }

--- a/pkg/chainfollower/chainfollower_test.go
+++ b/pkg/chainfollower/chainfollower_test.go
@@ -105,7 +105,7 @@ func TestRollbackMessage(t *testing.T) {
 		Confirmations:     -1,
 	})
 
-	chainPos, err := follower.fetchStartingPos(initialChainPos)
+	chainPos, err := follower.FetchStartingPos(initialChainPos)
 	if err != nil {
 		t.Errorf("Error fetching starting pos: %v", err)
 	}


### PR DESCRIPTION
Wanted to remove the loop from chainfollower as some people may or may not want to loop. This allows the caller to control the execution flow (whether they just loop, or have their own logic to process each block).